### PR TITLE
Fix Third Party Installation and Start

### DIFF
--- a/devices/index.js
+++ b/devices/index.js
@@ -1,0 +1,7 @@
+const kodiDevices = require('./kodi').devices;
+
+module.exports = {
+  devices: [
+    ...kodiDevices,
+  ],
+}

--- a/devices/kodi/index.js
+++ b/devices/kodi/index.js
@@ -16,7 +16,7 @@ console.log ('Kodi Driver by Niels de Klerk.');
 
 
 module.exports = {
-  devices: kodi,
+  devices: [kodi],
   buildKodiDriver
 }
 


### PR DESCRIPTION
With the new SDK you can also start drivers you have installed through ```npm install```. While this driver already works when you run ```neeo-sdk start``` inside the project folder, it does not when installed through ```npm install```:

```
❯ neeo-sdk start
/Users/mkohler/projects/cp6/sdk/neeo-sdk/cli/devicecontroller.js:53
    throw new Error(
    ^

Error: No devices found! Make sure you expose devices in the "devices" directory or install external drivers through npm.
```

This PR makes sure that both ways of starting the driver work.