### PR TITLE
Change "Player.Seek" to Kodi 16+ compatible syntax

### DIFF
--- a/devices/kodi/kodi-controller.js
+++ b/devices/kodi/kodi-controller.js
@@ -705,25 +705,25 @@ function sendContentAwareCommand(deviceId, method, params) {
                 if (!resp[`VideoPlayer.HasMenu`]) {
                   if (method == "Input.up") {
                     sendCommand(deviceId, "Player.Seek", {
-                      value: "bigforward",
+                      value: {step: "bigforward"},
                       playerid: 1
                     });
                   }
                   if (method == "Input.down") {
                     sendCommand(deviceId, "Player.Seek", {
-                      value: "bigbackward",
+                      value: {step: "bigbackward"},
                       playerid: 1
                     });
                   }
                   if (method == "Input.left") {
                     sendCommand(deviceId, "Player.Seek", {
-                      value: "smallbackward",
+                      value: {step: "smallbackward"},
                       playerid: 1
                     });
                   }
                   if (method == "Input.right") {
                     sendCommand(deviceId, "Player.Seek", {
-                      value: "smallforward",
+                      value: {step: "smallforward"},
                       playerid: 1
                     });
                   }


### PR DESCRIPTION
Fixes seek with arrow keys (up/down/left/right) on Kodi v19+.

On Kodi 16 and up, the "Player.Seek" command has been changed, but the legacy method was kept in place until Kodi 19. The current implementation of "Player.Seek" in NEEO Kodi Driver uses the legacy command parameter syntax - and this has been removed on Kodi v19. This means that the current library does not allow seek operations when used with Kodi v19 and above.

The fix is to change the legacy parameter syntax to the new expected syntax, which expects the legacy string argument to be wrapped in an object with a "seek" property name (to distinguish it from a "percentage" seek operation).

https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/105/files was used as reference for the new parameter syntax. Tested with Kodi 19.1 on LibreELEC 10.0.

Note: this is a breaking change that means Kodi versions 15 and earlier are no longer supported! However, v15 is pretty old by now (6+ years) and I doubt anyone still uses that version.